### PR TITLE
removes Step + doc

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * element).
  */
 @Root
-public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable<CtQuery> {
+public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable {
 
 	/**
 	 * Searches for an annotation (proxy) of the given class that annotates the

--- a/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
@@ -38,17 +38,17 @@ import java.util.List;
  * It makes sense to evaluate this query only once, because the input element is constant.<br>
  * A CtQuery is lazily evaluated once {{@link #list()}} or {@link #forEach(CtConsumer)} are called.
  * Usually a new query is created each time when one needs to query something.
- * If you need to reuse a query instance several times, for example in a loop, then use {@link CtQuery#setInput(Object)}
+ * If you need to reuse a query instance several times, for example in a loop, then use {@link CtQuery#setInput(Object...)}
  * to bound this query with different input.
  *
  * @param &lt;O> the type of the element produced by this query
  */
-public interface CtQuery extends CtQueryable.Step<CtQuery> {
+public interface CtQuery extends CtQueryable {
 
 	/**
-	 * sets input of the query. If the query is created by {@link CtElement#map} or {@link CtElement#filterChildren(Filter)},
-	 * then such query is already bound the input element.
-	 * Next call of {@link #setInput(Object...)} will reset current binding ans use new one.
+	 * sets (binds) the input of the query. If the query is created by {@link CtElement#map} or {@link CtElement#filterChildren(Filter)},
+	 * then the query is already bound to this element.
+	 * A new call of {@link #setInput(Object...)} will reset the current binding ans use the new one.
 	 *
 	 * @param input
 	 * @return this to support fluent API
@@ -63,6 +63,7 @@ public interface CtQuery extends CtQueryable.Step<CtQuery> {
 	/**
 	 * actually evaluates the query and returns all the produced elements collected in a List
 	 * @return the list of elements collected by the query.
+	 * @see #forEach(CtConsumer) for an efficient way of manipulating the elements without creating an intermediate list.
 	 */
 	List<Object> list();
 	/**
@@ -71,4 +72,23 @@ public interface CtQuery extends CtQueryable.Step<CtQuery> {
 	 * @return the list of elements collected by the query.
 	 */
 	<R> List<R> list(Class<R> itemClass);
+
+	/**
+	 * Defines whether this query will throw {@link ClassCastException}
+	 * when the output of the previous step cannot be cast to type of input of next step.
+	 * The default value is {@link QueryFailurePolicy#FAIL}<br>
+	 *
+	 * Note: The {@link CtQueryable#filterChildren(Filter)} step never throws {@link ClassCastException}
+	 *
+	 * @param policy the policy
+	 * @return this to support fluent API
+	 */
+	CtQuery failurePolicy(QueryFailurePolicy policy);
+
+	/**
+	 * Sets the name of current query, to identify the current step during debugging of a query
+	 * @param name
+	 * @return this to support fluent API
+	 */
+	CtQuery name(String name);
 }

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -135,13 +135,13 @@ public class CtQueryImpl implements CtQuery {
 	}
 
 	@Override
-	public CtQueryImpl name(String name) {
+	public CtQuery name(String name) {
 		getLastStep().setName(name);
 		return this;
 	}
 
 	@Override
-	public CtQueryImpl failurePolicy(QueryFailurePolicy policy) {
+	public CtQuery failurePolicy(QueryFailurePolicy policy) {
 		failurePolicy = policy;
 		return this;
 	}

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryable.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryable.java
@@ -27,9 +27,8 @@ import spoon.reflect.visitor.Filter;
  * children of an element.
  * <li> by {@link CtQuery} to allow chaining query steps.
  * </ol>
- * @param <T> the type of returned query
  */
-public interface CtQueryable<T> {
+public interface CtQueryable {
 
 	/**
 	 * Query elements based on a function, the behavior depends on the return type of the function.
@@ -44,7 +43,7 @@ public interface CtQueryable<T> {
 	 * @param function a Function with one parameter of type I returning a value of type R
 	 * @return a new query object
 	 */
-	<I, R> T map(CtFunction<I, R> function);
+	<I, R> CtQuery map(CtFunction<I, R> function);
 
 	/**
 	 * Query elements based on a CtQueryStep, which supports efficient implementation of CtScanner based queries,
@@ -53,7 +52,7 @@ public interface CtQueryable<T> {
 	 * @param queryStep
 	 * @return the created QueryStep, which is the new last step of the query
 	 */
-	<I> T map(CtConsumableFunction<I> queryStep);
+	<I> CtQuery map(CtConsumableFunction<I> queryStep);
 
 	/**
 	 * Recursively scans all children elements of an input element.
@@ -68,31 +67,5 @@ public interface CtQueryable<T> {
 	 * @param filter used to filter scanned children elements of the AST tree
 	 * @return a new Query
 	 */
-	<R extends CtElement> T filterChildren(Filter<R> filter);
-
-	/**
-	 * Defines helper methods of query step
-	 *
-	 * @param <T> the type of returned query
-	 */
-	interface Step<T> extends CtQueryable<T> {
-		/**
-		 * Defines whether this query will throw {@link ClassCastException}
-		 * when the output of the previous step cannot be cast to type of input of next step.
-		 * The default value is {@link QueryFailurePolicy#FAIL}<br>
-		 *
-		 * Note: The {@link CtQueryable#filterChildren(Filter)} step never throws {@link ClassCastException}
-		 *
-		 * @param policy the policy
-		 * @return this to support fluent API
-		 */
-		T failurePolicy(QueryFailurePolicy policy);
-
-		/**
-		 * Sets the name of current query, to identify the current step during debugging of a query
-		 * @param name
-		 * @return this to support fluent API
-		 */
-		T name(String name);
-	}
+	<R extends CtElement> CtQuery filterChildren(Filter<R> filter);
 }


### PR DESCRIPTION
Hi Pavel,

I really like this solution, which integrates all the points we've discussed. Thanks for it.

A last simplification point is about Step and the generics of CtQueryable, which I find complex and non-understandable.

Are they really required? It does not  seem to be the case, here is a PR without them.

What do you think?

If we agree on this, I proceed with more documentation changes.